### PR TITLE
Fix broken initialization of `Firebase::Admin::Messaging::MulticastMessage`

### DIFF
--- a/lib/firebase/admin/messaging/multicast_message.rb
+++ b/lib/firebase/admin/messaging/multicast_message.rb
@@ -30,6 +30,15 @@ module Firebase
         #   Registration token of the device to which the message should be sent (optional).
         attr_accessor :tokens
 
+        # @return [String, nil]
+        #   Name of the FCM topic to which the message should be sent (optional). Topic name may contain the `/topics/`
+        #   prefix.
+        attr_accessor :topic
+
+        # @return [String, nil]
+        #   The FCM condition to which the message should be sent (optional).
+        attr_accessor :condition
+
         # Initializes a {Message}.
         #
         # @param [Hash<String, String>, nil] data
@@ -44,13 +53,20 @@ module Firebase
         #   An {FCMOptions} (optional).
         # @param [Array<String>, nil] tokens
         #   A registration token of the device to send the message to (optional).
+        # @param [String, nil] topic
+        #   The name of the FCM topic to send the message to (optional).
+        #   The topic name may contain the `/topics/` prefix.
+        # @param [String, nil] condition
+        #   The FCM condition to which the message should be sent (optional)
         def initialize(
           data: nil,
           notification: nil,
           android: nil,
           apns: nil,
           fcm_options: nil,
-          tokens: nil
+          tokens: nil,
+          topic: nil,
+          condition: nil
         )
           self.data = data
           self.notification = notification

--- a/spec/unit/firebase/admin/messaging/multicast_message_spec.rb
+++ b/spec/unit/firebase/admin/messaging/multicast_message_spec.rb
@@ -1,0 +1,19 @@
+describe Firebase::Admin::Messaging::MulticastMessage do
+  describe "#initialize" do
+    context "given no parameters" do
+      it "should return a message object" do
+        message = Firebase::Admin::Messaging::MulticastMessage.new
+        expect(message).to have_attributes(
+          data: nil,
+          notification: nil,
+          android: nil,
+          apns: nil,
+          fcm_options: nil,
+          tokens: nil,
+          topic: nil,
+          condition: nil
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello. 

I found a broken initialization of `Firebase::Admin::Messaging::MulticastMessage`. The class does not have `topic` method nor `condition` method.

I brought those descriptions from https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages.